### PR TITLE
Handle HTTPoison redirects

### DIFF
--- a/lib/soap.ex
+++ b/lib/soap.ex
@@ -106,7 +106,8 @@ defmodule Soap do
       {:ok, %Soap.Response{}}
 
   """
-  @spec call(wsdl :: map(), operation :: String.t(), params :: map(), headers :: any(), opts :: any()) :: any()
+  @spec call(wsdl :: map(), operation :: String.t(), params :: map(), headers :: any(), opts :: any()) ::
+          {:ok, Response.t()} | {:error, any()}
   def call(wsdl, operation, params, headers \\ [], opts \\ []) do
     wsdl
     |> validate_operation(operation)

--- a/lib/soap/request.ex
+++ b/lib/soap/request.ex
@@ -9,7 +9,9 @@ defmodule Soap.Request do
 
   Calling HTTPoison request by Map with method, url, body, headers, options keys.
   """
-  @spec call(wsdl :: map(), operation :: String.t(), params :: any(), headers :: any(), opts :: any()) :: any()
+  @spec call(wsdl :: map(), operation :: String.t(), params :: any(), headers :: any(), opts :: any()) ::
+          {:ok, HTTPoison.Response.t() | HTTPoison.AsyncResponse.t() | HTTPoison.MaybeRedirect.t()}
+          | {:error, HTTPoison.Error.t()}
   def call(wsdl, operation, soap_headers_and_params, request_headers \\ [], opts \\ [])
 
   def call(wsdl, operation, {soap_headers, params}, request_headers, opts) do

--- a/lib/soap/request.ex
+++ b/lib/soap/request.ex
@@ -17,11 +17,20 @@ defmodule Soap.Request do
     request_headers = Headers.build(wsdl, operation, request_headers)
     body = Params.build_body(wsdl, operation, params, soap_headers)
 
-    get_http_client().post(url, body, request_headers, opts)
+    case execute_request(url, body, request_headers, opts) do
+      {:ok, %HTTPoison.MaybeRedirect{redirect_url: redirect_url}} ->
+        execute_request(redirect_url, body, request_headers, opts)
+
+      response ->
+        response
+    end
   end
 
   def call(wsdl, operation, params, request_headers, opts),
     do: call(wsdl, operation, {%{}, params}, request_headers, opts)
+
+  defp execute_request(url, body, request_headers, opts),
+    do: get_http_client().post(url, body, request_headers, opts)
 
   @spec get_http_client() :: HTTPoison.Base
   def get_http_client do

--- a/lib/soap/wsdl.ex
+++ b/lib/soap/wsdl.ex
@@ -11,7 +11,7 @@ defmodule Soap.Wsdl do
 
   alias Soap.{Request, Type, Xsd}
 
-  @spec parse_from_file(String.t()) :: {:ok, map()}
+  @spec parse_from_file(String.t()) :: {:ok, map()} | no_return()
   def parse_from_file(path, opts \\ []) do
     {:ok, wsdl} = File.read(path)
     parse(wsdl, path, opts)
@@ -76,9 +76,7 @@ defmodule Soap.Wsdl do
 
       xpath(
         wsdl,
-        ~x"//#{ns("types", protocol_ns)}/#{ns("schema", schema_namespace)}/#{ns("import", schema_namespace)}[@namespace='#{
-          value
-        }']"
+        ~x"//#{ns("types", protocol_ns)}/#{ns("schema", schema_namespace)}/#{ns("import", schema_namespace)}[@namespace='#{value}']"
       ) ->
         {string_key, %{value: value, type: :xsd}}
 
@@ -91,9 +89,7 @@ defmodule Soap.Wsdl do
   def get_endpoint(wsdl, protocol_ns, soap_ns) do
     wsdl
     |> xpath(
-      ~x"//#{ns("definitions", protocol_ns)}/#{ns("service", protocol_ns)}/#{ns("port", protocol_ns)}/#{
-        ns("address", soap_ns)
-      }/@location"s
+      ~x"//#{ns("definitions", protocol_ns)}/#{ns("service", protocol_ns)}/#{ns("port", protocol_ns)}/#{ns("address", soap_ns)}/@location"s
     )
   end
 


### PR DESCRIPTION
HTTPoison only handles redirects to the status `303` in `POST` requests.
When the status code is different it returns a `HTTPoison.MaybeRedirect`
with the link to the redirect. On this commit we are handle any
redirects from the HTTPoison.
